### PR TITLE
Hotfix node fetch types

### DIFF
--- a/src/solidFetch.ts
+++ b/src/solidFetch.ts
@@ -14,7 +14,7 @@ import {Token} from "./util/AccessToken"
 
 const path = require('path');
 
-import nodeFetch from 'node-fetch';
+import nodeFetch, {Response as nf_response} from 'node-fetch';
 
 const STORAGE = path.resolve("config", "data.json")
 
@@ -33,7 +33,7 @@ type cacheRecord = {
     secret: string
 }
 
-async function responseToQuads(response: Response) {
+async function responseToQuads(response: nf_response | Response) {
     const data = await response.text();
     const ct = response.headers.get(CONTENT_TYPE)
 
@@ -84,7 +84,7 @@ export default class SolidFetch {
     private inruptSession: Session;
 
     async fetch(url: string, webID: string): Promise<Quad[]> {
-        let result: Response
+        let result: nf_response
         let failed = false
         // Step -1: try to fetch resource without authentication/authorization
         try {

--- a/src/solidFetch.ts
+++ b/src/solidFetch.ts
@@ -219,7 +219,7 @@ export default class SolidFetch {
                     this.CSSTokenCache[webID] = new Token(accessToken, expiration, dpopKey);
                 }
                 const accessToken = this.CSSTokenCache[webID];
-                const authFetch = await buildAuthenticatedFetch(nodeFetch, accessToken.value(), {dpopKey: accessToken.key()});
+                const authFetch = await buildAuthenticatedFetch(fetch, accessToken.value(), {dpopKey: accessToken.key()});
                 const result = await authFetch(url);
 
                 return await responseToQuads(result);


### PR DESCRIPTION
PR to fix issue https://github.com/sevrijss/long_term_auth/issues/4. Something broke the similarity between the Typescript `Response` type and the internal node-fetch `Response` type, breaking the cast. Changed the `buildAuthenticatedFetch` call now takes a normal `fetch` function instead of the `node-fetch` function.